### PR TITLE
handle valid error

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-exports.ResourcesFailureError = exports.ResourcesExistError = exports.NetworkError = exports.ValidationError = undefined;
+exports.ValidError = exports.ResourcesFailureError = exports.ResourcesExistError = exports.NetworkError = exports.ValidationError = undefined;
 exports.default = error;
 
 var _koaOnerror = require('koa-onerror');
@@ -35,6 +35,9 @@ function error(options = {}) {
                 ctx.body = { message: err.name, errors: [err.message] };
             } else if (err instanceof NetworkError) {
                 ctx.status = 502;
+                ctx.body = { message: err.name, errors: [err.message] };
+            } else if (err instanceof ValidError) {
+                ctx.status = 201;
                 ctx.body = { message: err.name, errors: [err.message] };
             } else {
                 throw err;
@@ -91,3 +94,15 @@ class ResourcesFailureError extends Error {
     }
 }
 exports.ResourcesFailureError = ResourcesFailureError;
+class ValidError extends Error {
+    constructor(message) {
+        super();
+        this.message = {
+            message: message,
+            code: 'validation'
+        };
+        this.name = 'Error is valid';
+        Error.captureStackTrace(this, this.constructor);
+    }
+}
+exports.ValidError = ValidError;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "halo-error",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/halojs/halo-error"

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,9 @@ export default function error (options = {}) {
             } else if (err instanceof NetworkError) {
                 ctx.status = 502
                 ctx.body = { message: err.name, errors: [err.message] }
+            } else if (err instanceof ValidError) {
+                ctx.status = 201
+                ctx.body = { message: err.name, errors: [err.message] }
             } else {
                 throw err
             }
@@ -72,6 +75,17 @@ export class ResourcesFailureError extends Error {
             code: 'failure'
         }
         this.name = 'Resources Failure'
+        Error.captureStackTrace(this, this.constructor)
+    }
+}
+export class ValidError extends Error {
+    constructor(message) {
+        super()
+        this.message = {
+            message: message,
+            code: 'validError'
+        }
+        this.name = 'Error is valid'
         Error.captureStackTrace(this, this.constructor)
     }
 }


### PR DESCRIPTION
add valid error in the normal logic:

for example: 
```
throw new ValidError('this is a normal error')
```

return the normal json: 
```
{
  "message": "Error is valid",
  "errors": [
    {
      "message": "this is a normal error",
      "code": "validation"
    }
  ]
}
```